### PR TITLE
Bug fixes

### DIFF
--- a/modules/models.py
+++ b/modules/models.py
@@ -7,6 +7,7 @@ from sqlalchemy.types import TypeDecorator, TEXT
 from sqlalchemy.types import Enum as SQLEnum
 from werkzeug.security import generate_password_hash, check_password_hash
 from argon2 import PasswordHasher
+from argon2.exceptions import VerifyMismatchError
 from datetime import datetime
 import uuid, json
 from uuid import uuid4
@@ -321,7 +322,7 @@ class User(db.Model):
         if self.password_hash.startswith('$argon2'):
             try:
                 return ph.verify(self.password_hash, password)
-            except argon2_exceptions.VerifyMismatchError:
+            except VerifyMismatchError:
                 return False
         else:
             # Fallback to the old bcrypt checking

--- a/modules/static/js/library_pagination.js
+++ b/modules/static/js/library_pagination.js
@@ -229,7 +229,9 @@ $(document).ready(function() {
                     message = '<p>No games or libraries found. Complain to the Captain of this vessel!</p>';
                 }
                 // Append the message to the gamesContainer
-                $('#gamesContainer').append(message);
+				if( $('#gamesContainer').empty() ){
+					$('#gamesContainer').append(message);
+				}
             },
             error: function() {
                 // Handle errors, e.g., if the endpoint is unreachable

--- a/modules/utilities.py
+++ b/modules/utilities.py
@@ -70,7 +70,7 @@ def send_password_reset_email(user_email, token):
     reset_url = url_for('main.reset_password', token=token, _external=True)
     msg = MailMessage(
         'Avast Ye! Password Reset Request Arrr!',
-        sender='Blackbeard@Sharewarez.com', 
+        sender=current_app.config['MAIL_DEFAULT_SENDER'], 
         recipients=[user_email]
     )
     msg.body = '''Ahoy there!
@@ -93,7 +93,7 @@ Captain Blackbeard
 
 <p>Captain Blackbeard</p>
 
-<p>P.S. If ye be havin' any troubles, send a message to the crew at <a href="mailto:Blackbeard@Sharewarez.com">Blackbeard@Sharewarez.com</a>, and we'll help ye navigate yer way back into yer account! Arrr!</p>
+<p>P.S. If ye be havin' any troubles, send a message to the crew at <a href="mailto:{current_app.config['MAIL_DEFAULT_SENDER']}">{current_app.config['MAIL_DEFAULT_SENDER']}</a>, and we'll help ye navigate yer way back into yer account! Arrr!</p>
 '''
     mail.send(msg)
 


### PR DESCRIPTION
In the password reset email that is sent it now has the sending email address in the message body. Probably would be nice to either have a different "replyto" option or the ability for the user to edit the message body altogether. Otherwise if sent from a noreply email it will list that.